### PR TITLE
Skill Tree Key Closes GUI

### DIFF
--- a/src/main/java/zdoctor/skilltree/client/gui/GuiSkillTree.java
+++ b/src/main/java/zdoctor/skilltree/client/gui/GuiSkillTree.java
@@ -227,6 +227,15 @@ public class GuiSkillTree extends GuiSkillScreen {
 		}
 
 	}
+	
+	@Override
+	protected void keyTyped(char par1, int par2) throws IOException {
+		if (par2 == KeyHandler.OPEN_SKILL_TREE.getKeyCode()) {
+			this.mc.player.closeScreen();
+		} else {
+			super.keyTyped(par1, par2);
+		} 
+	}
 
 	@Override
 	protected void mouseReleased(int mouseX, int mouseY, int state) {


### PR DESCRIPTION
Allow the same key that opens the GUI to close it too.